### PR TITLE
Request Context Done instead of Close Notifier

### DIFF
--- a/server.go
+++ b/server.go
@@ -110,8 +110,8 @@ func (b *Broker) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// receive updates
 	b.newClients <- messageChan
 
-	// Listen to the closing of the http connection via the CloseNotifier
-	notify := w.(http.CloseNotifier).CloseNotify()
+	// Listen to the closing of the http connection via the Request.Context
+	notify := r.Context().Done()
 	go func() {
 		<-notify
 		// Remove this client from the map of attached clients


### PR DESCRIPTION
According to the documentation the Close Notifier is deprecated.
https://pkg.go.dev/net/http#CloseNotifier

I suggest to use the request context instead.

Quote from the CloseNotifier documenation:
> 
> The CloseNotifier interface is implemented by ResponseWriters which allow detecting when the underlying connection has gone away.
> 
> This mechanism can be used to cancel long operations on the server if the client has disconnected before the response is ready.
> 
> Deprecated: the CloseNotifier interface predates Go's context package. New code should use Request.Context instead. 

Quote from the Request.Context https://pkg.go.dev/net/http?utm_source=gopls#Request.Context

> Context returns the request's context. To change the context, use Clone or WithContext.
> 
> The returned context is always non-nil; it defaults to the background context.
> 
> For outgoing client requests, the context controls cancellation.
> 
> For incoming server requests, the context is canceled when the client's connection closes, the request is canceled (with HTTP/2), or when the ServeHTTP method returns. 